### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.4
+FROM golang:1.15.2
 
 ENV GO111MODULE=on
 


### PR DESCRIPTION
Bump go version to `1.15.2`

This bump is specifically to support bare importing of the `time/tzinfo` package into `main` per this issue: https://github.com/wtfutil/wtf/pull/997

Go versions prior to `1.15` would error out when attempting to `import _ "time/tzinfo"`.