### PR TITLE
Bump go 1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.17-buster
+FROM golang:1.19.2-bullseye
 
 ENV GO111MODULE=on
 
 RUN apt-get update && \
 	apt-get -y install jq
 
-RUN go install github.com/kisielk/errcheck@v1.6.0
+RUN go install github.com/kisielk/errcheck@v1.6.2
 RUN go install golang.org/x/tools/cmd/goimports@latest
 RUN go install golang.org/x/lint/golint@latest
 RUN go install github.com/securego/gosec/cmd/gosec@latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.2
+FROM golang:1.16.5-buster
 
 ENV GO111MODULE=on
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM golang:1.16.5-buster
+FROM golang:1.17-buster
 
 ENV GO111MODULE=on
 
 RUN apt-get update && \
-	apt-get -y install jq && \
-	go get -u \
-		github.com/kisielk/errcheck \
-		golang.org/x/tools/cmd/goimports \
-		golang.org/x/lint/golint \
-		github.com/securego/gosec/cmd/gosec \
-		golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow \
-		honnef.co/go/tools/cmd/staticcheck
+	apt-get -y install jq
+
+RUN go install github.com/kisielk/errcheck@v1.6.0
+RUN go install golang.org/x/tools/cmd/goimports@latest
+RUN go install golang.org/x/lint/golint@latest
+RUN go install github.com/securego/gosec/cmd/gosec@latest
+RUN go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow@latest
+RUN go install honnef.co/go/tools/cmd/staticcheck@latest
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -12,31 +12,31 @@ Runs `gofmt` and comments back on error.
 Runs `go vet` and comments back on error.
 
 ### Shadow
-Runs `go vet --vettool=/go/bin/shadow` and comments back on error.  
+Runs `go vet --vettool=/go/bin/shadow` and comments back on error.
 Use: [golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow](https://godoc.org/golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow)
 
 ### Imports
-Runs `goimports` and comments back on error.  
+Runs `goimports` and comments back on error.
 Use: [golang.org/x/tools/cmd/goimports](https://godoc.org/golang.org/x/tools/cmd/goimports)
 <img src="./assets/imports.png" alt="Imports Action" width="80%" />
 
 ### Lint
-Runs `golint` and comments back on error.  
+Runs `golint` and comments back on error.
 Use: [golang.org/x/lint/golint](https://github.com/golang/lint)
 <img src="./assets/lint.png" alt="Lint Action" width="80%" />
 
 ### Staticcheck
-Runs `staticcheck` and comments back on error.  
+Runs `staticcheck` and comments back on error.
 Use: [honnef.co/go/tools/cmd/staticcheck](https://staticcheck.io/)
 <img src="./assets/staticcheck.png" alt="Staticcheck Action" width="80%" />
 
 ### Errcheck
-Runs `errcheck` and comments back on error.  
+Runs `errcheck` and comments back on error.
 Use: [github.com/kisielk/errcheck](https://github.com/kisielk/errcheck)
 <img src="./assets/errcheck.png" alt="Errcheck Action" width="80%" />
 
 ### Sec
-Runs `gosec` and comments back on error.  
+Runs `gosec` and comments back on error.
 Use: [github.com/securego/gosec/cmd/gosec](https://github.com/securego/gosec)
 <img src="./assets/sec.png" alt="Sec Action" width="80%" />
 
@@ -55,7 +55,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: check
-      uses: grandcolline/golang-github-actions@v1.1.0
+      uses: k8s-school/golang-github-actions@v1.1.2
       with:
         run: imports
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -66,7 +66,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: check
-      uses: grandcolline/golang-github-actions@v1.1.0
+      uses: k8s-school/golang-github-actions@v1.1.2
       with:
         run: errcheck
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -77,7 +77,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: check
-      uses: grandcolline/golang-github-actions@v1.1.0
+      uses: k8s-school/golang-github-actions@v1.1.2
       with:
         run: lint
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -88,7 +88,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: check
-      uses: grandcolline/golang-github-actions@v1.1.0
+      uses: k8s-school/golang-github-actions@v1.1.2
       with:
         run: shadow
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -99,7 +99,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: check
-      uses: grandcolline/golang-github-actions@v1.1.0
+      uses: k8s-school/golang-github-actions@v1.1.2
       with:
         run: staticcheck
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -110,7 +110,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: check
-      uses: grandcolline/golang-github-actions@v1.1.0
+      uses: k8s-school/golang-github-actions@v1.1.2
       with:
         run: sec
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
A release should also be created in order to use easily this version. `staticchek` and `shadow` requires go > 1.15 to work fine.