### PR TITLE
Add support to exclude packages/paths

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: "if this is true, do not detect 'defer' with error. This is only valid when run is errcheck."
     default: false
     required: false
+  exclude:
+    description: "paths to exclude from checks."
+    default: ""
+    required: false
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -35,6 +39,7 @@ runs:
     - ${{ inputs.token }}
     - ${{ inputs.flags }}
     - ${{ inputs.ignore-defer }}
+    - ${{ inputs.exclude }}
 branding:
   icon: "alert-triangle"
   color: "yellow"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,7 @@ SEND_COMMNET=$3
 GITHUB_TOKEN=$4
 FLAGS=$5
 IGNORE_DEFER_ERR=$6
+EXCLUDE=$7
 
 COMMENT=""
 SUCCESS=0
@@ -37,6 +38,10 @@ mod_download() {
 check_errcheck() {
 	if [ "${IGNORE_DEFER_ERR}" = "true" ]; then
 		IGNORE_COMMAND="| grep -v defer"
+	fi
+
+	if [ -n "${EXCLUDE}" ]; then
+		FLAGS="-ignorepkg ${EXCLUDE} ${FLAGS}"
 	fi
 
 	set +e


### PR DESCRIPTION
- Only works for checks that support exclusions (`errcheck`)
- Other checks silently ignore the setting, since they don't support it

There might be some fancy magic we could do with, say, `find -type f -iname '*.go' ...` instead of `./...`, but even that only works for checks that support lists of files rather than just a single package name/path. Or, well, we'd have to do some major refactoring on the checks that don't support file lists. And probably all the checks, at that, since command lines have a length limit, so large projects would break the logic with a full listing of all non-excluded files.

Anyway, this is the best I can do at the moment without addressing the problems above. Addresses #11.

Enjoy!