### PR TITLE
Upgrade go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,15 @@
-FROM golang:1.15.2
+FROM golang:1.18
 
 ENV GO111MODULE=on
 
 RUN apt-get update && \
 	apt-get -y install jq && \
-	go get -u \
-		github.com/kisielk/errcheck \
-		golang.org/x/tools/cmd/goimports \
-		golang.org/x/lint/golint \
-		github.com/securego/gosec/cmd/gosec \
-		golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow \
-		honnef.co/go/tools/cmd/staticcheck
+	go install github.com/kisielk/errcheck@latest && \
+	go install golang.org/x/tools/cmd/goimports@latest && \
+	go install golang.org/x/lint/golint@latest && \
+	go install github.com/securego/gosec/cmd/gosec@latest && \
+	go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow@latest && \
+	go install honnef.co/go/tools/cmd/staticcheck@latest
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.20
 
 ENV GO111MODULE=on
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20
+FROM golang:latest
 
 ENV GO111MODULE=on
 


### PR DESCRIPTION
By #20, the CI fails due to go version incompatibility.
This PR upgrades go version to 1.18 and fixes the error.