### PR TITLE
Local gosec

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Related issues
+
+Closes: #
+
+## Description
+
+Please include a summary of the change. Please also include relevant motivation and context.
+
+## Checklist
+Before requesting reviews, check all boxes below.
+
+- [ ] I have left self-review comments to help other reviewers.
+- [ ] My PR is as small as possible and focused on a single task.md#api-checklist).
+- [ ] I have considered and implemented security best practices
+- [ ] If tagging multiple reviewers, I have made specific asks.
+
+## Manual testing
+Before marking as "ready for production", check all boxes below.
+
+- [ ] List all the verification steps you'll perform here (at least one)
+
+## Production readiness
+Before merging, "ready" should be checked.
+
+- [ ] WIP: it's not ready for review
+- [ ] Pending: it's not ready for production
+- [ ] Ready: it's ready for production

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.2
+FROM golang:1.17
 
 ENV GO111MODULE=on
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
 	go install github.com/kisielk/errcheck@latest && \
 	go install golang.org/x/tools/cmd/goimports@latest && \
 	go install golang.org/x/lint/golint@latest && \
-	go install github.com/securego/gosec/cmd/gosec@latest && \
+	go install github.com/securego/gosec/v2/cmd/gosec@latest && \
 	go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow@latest && \
 	go install honnef.co/go/tools/cmd/staticcheck@latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,11 @@ RUN apt-get update && \
 	go install github.com/kisielk/errcheck@latest && \
 	go install golang.org/x/tools/cmd/goimports@latest && \
 	go install golang.org/x/lint/golint@latest && \
-	go install github.com/securego/gosec/v2/cmd/gosec@latest && \
 	go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow@latest && \
 	go install honnef.co/go/tools/cmd/staticcheck@latest
+
+# Manually install a patched version of gosec
+RUN git clone https://github.com/convictional/gosec && cd gosec && go install . && cd ..
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,15 @@
-FROM golang:1.17
+FROM golang:1.18
 
 ENV GO111MODULE=on
 
 RUN apt-get update && \
 	apt-get -y install jq && \
-	go get -u \
-		github.com/kisielk/errcheck \
-		golang.org/x/tools/cmd/goimports \
-		golang.org/x/lint/golint \
-		github.com/securego/gosec/cmd/gosec \
-		golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow \
-		honnef.co/go/tools/cmd/staticcheck
+	go install github.com/kisielk/errcheck@latest && \
+	go install golang.org/x/tools/cmd/goimports@latest && \
+	go install golang.org/x/lint/golint@latest && \
+	go install github.com/securego/gosec/cmd/gosec@latest && \
+	go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow@latest && \
+	go install honnef.co/go/tools/cmd/staticcheck@latest
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,14 +1,21 @@
-           DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
-                   Version 2, December 2004
+MIT License
 
-Copyright (C) 2019 grandcolline
+Copyright (c) 2021 Convictional, Inc.
 
-Everyone is permitted to copy and distribute verbatim or modified
-copies of this license document, and changing it is allowed as long
-as the name is changed.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-           DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
-  TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
- 0. You just DO WHAT THE FUCK YOU WANT TO.
-
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,14 @@
-MIT License
+           DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+                   Version 2, December 2004
 
-Copyright (c) 2021 Convictional, Inc.
+Copyright (C) 2019 grandcolline
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Everyone is permitted to copy and distribute verbatim or modified
+copies of this license document, and changing it is allowed as long
+as the name is changed.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+           DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+  TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+ 0. You just DO WHAT THE FUCK YOU WANT TO.
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,7 +61,7 @@ ${OUTPUT}
 # check_fmt is excute "go fmt" and generate ${COMMENT} and ${SUCCESS}
 check_fmt() {
 	set +e
-	UNFMT_FILES=$(sh -c "gofmt -l -s . $*" 2>&1)
+	UNFMT_FILES=$(sh -c "gofmt -l . $*" 2>&1)
 	test -z "${UNFMT_FILES}"
 	SUCCESS=$?
 


### PR DESCRIPTION
This change modifies the dockerfile to build gosec from a forked copy of gosec located in https://github.com/convictional/gosec.

The version located there has had it's go/tools package version bumped to avoid an issue detailed here: https://github.com/golang/go/issues/51629. A PR to fix it upstream is here: https://github.com/securego/gosec/pull/817